### PR TITLE
Test to show how redis_attrs is conflicting with the ruby Time class.

### DIFF
--- a/lib/redis-attrs.rb
+++ b/lib/redis-attrs.rb
@@ -56,7 +56,7 @@ class Redis
         string:  Redis::Attrs::String,
         boolean: Redis::Attrs::Boolean,
         date:    Redis::Attrs::Date,
-        time:    Redis::Attrs::Time,
+        time:    Redis::Attrs::RaTime,
         integer: Redis::Attrs::Integer,
         float:   Redis::Attrs::Float,
 
@@ -82,7 +82,7 @@ class Redis
     autoload :String,  'redis-attrs/string'
     autoload :Boolean, 'redis-attrs/boolean'
     autoload :Date,    'redis-attrs/date'
-    autoload :Time,    'redis-attrs/time'
+    autoload :RaTime,    'redis-attrs/ra_time'
     autoload :Integer, 'redis-attrs/integer'
     autoload :Float,   'redis-attrs/float'
     autoload :Complex, 'redis-attrs/complex'

--- a/lib/redis-attrs/ra_time.rb
+++ b/lib/redis-attrs/ra_time.rb
@@ -1,6 +1,6 @@
 class Redis
   module Attrs
-    class Time < Scalar
+    class RaTime < Scalar
       def deserialize(value)
         value.nil? ? nil : ::Time.parse(value)
       end

--- a/spec/redis_attrs_spec.rb
+++ b/spec/redis_attrs_spec.rb
@@ -179,4 +179,18 @@ describe Redis::Attrs do
       film.genres.members.sort.should == ["action", "drama", "film noir", "western"]
     end
   end
+
+  describe "bugs" do
+    it "should not interfere with the ruby Time class" do
+      class Film
+        def year_test
+          Time.now.year
+        end
+      end
+
+      expect(film.year_test).to eq(Time.now.year)
+    end
+  end
+
+
 end


### PR DESCRIPTION
Ernesto, I found this bug when using ruby Time in a class that includes redis-attrs. I was thinking that renaming the time class in redis-attrs would do the trick but thought I'd pass it by you. I haven't checked but I'm assuming the same problem will exist with the other class names like Integer, Float, Hash etc. If I don't hear from you, I'll rename them all to something like RaTime...
